### PR TITLE
fix: changed copy command

### DIFF
--- a/local-convert.sh
+++ b/local-convert.sh
@@ -22,7 +22,7 @@ then
   rm -rf $outputDir
   mkdir $outputDir
   echo "copying '$inputDir' to '$outputDir'"
-  cp -r -v $inputDir/ $outputDir
+  cp -r -v $inputDir/. $outputDir
   pwd
   ./$outputDir/scripts/docker-convert.sh $outputDir $convertSlides
 else


### PR DESCRIPTION
The error happens when local-convert.sh tries to use a script in the copied folder but the path is wrong because it copies the inputDir as well.

old behaviour: 

![Screenshot from 2023-11-17 16-36-12](https://github.com/htl-leonding-college/asciidoctor-html-template/assets/91525610/96c7549b-aca4-4686-8e45-ff7d4314f045)

Tobias Aichinger (4. Bhif)